### PR TITLE
functional implementation of {recall,precision}(-sensible)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,7 @@
     [org.clojure/clojure "1.8.0"]
     [org.clojure/tools.logging "0.3.1"]
     [org.clojure/tools.cli "0.3.3"]
-    [org.clojure/data.json "0.2.6"]]
+    [org.clojure/data.json "0.2.6"]
+    [org.clojure/math.combinatorics "0.1.3"]
+  ]
   :main clojure-bcubed.core)

--- a/src/clojure_bcubed/core.clj
+++ b/src/clojure_bcubed/core.clj
@@ -4,7 +4,6 @@
         [clojure.tools.logging :as log]
         [clojure.data.json :as json]
         [clojure.math.combinatorics :as combo])
-    (:use clojure.contrib.command-line)
     (:gen-class))
 
 ; (def original {:hi [2 3 4] :bye [6 7 8 9]})
@@ -17,9 +16,12 @@
                    (float (count (set/intersection set2_1 set2_2))))
               (float (count (set/intersection set2_1 set2_2))))))
 
-(defn multi-recall [dict1 dict2]
-    (log/info "Starting recall")
-    (average recall (filter set/intersection (combo/subsets (keys dict1)))
+(defn multi-recall [ldict cdict]
+  (filter
+    (fn [l] (not= #{} (set/intersection (ldict (first l)) (ldict (last l)))))
+    (combo/selections (keys cdict) 2)
+  )
+    (average recall (filter (fn [l] (set/intersection (ldict (first l)) (ldict (last l)) (combo/selections (keys cdict)))))
     ; (for [keyval1 dict1 keyval2 dict1]
     ;     (do (let [di2el1 (set (dict2 (key keyval1)))
     ;               di2el2 (set (dict2 (key keyval2)))]
@@ -44,14 +46,5 @@
                 (precision di1el1 di1el2 di2el1 di2el2)))))))
 
 (defn -main [& args]
-    (with-command-line args
-      "Necessary?"
-      [[orig "Ground truth data json file" 1]
-       [modi "Json file to be tested for improvements" 2]]
-    (def original (json/read-str (slurp orig)
-        :key-fn keyword))
-    (def modified (json/read-str (slurp modi)
-        :key-fn keyword))
-    (log/info "Number of clusters:" (count original))
-    (log/info (average (multi-recall original modified)))
-    (log/info (average (multi-precision original modified)))))
+  true
+)

--- a/src/clojure_bcubed/core.clj
+++ b/src/clojure_bcubed/core.clj
@@ -2,7 +2,8 @@
     (:require
         [clojure.set :as set]
         [clojure.tools.logging :as log]
-        [clojure.data.json :as json])
+        [clojure.data.json :as json]
+        [clojure.math.combinatorics :as combo])
     (:use clojure.contrib.command-line)
     (:gen-class))
 
@@ -18,13 +19,14 @@
 
 (defn multi-recall [dict1 dict2]
     (log/info "Starting recall")
-    (for [keyval1 dict1 keyval2 dict1]
-        (do (let [di2el1 (set (dict2 (key keyval1)))
-                  di2el2 (set (dict2 (key keyval2)))]
-            (if (set/intersection di2el1 di2el2)
-                (let [di1el1 (set (dict1 (key keyval1)))
-                      di1el2 (set (dict1 (key keyval2)))]
-                (recall di1el1 di1el2 di2el1 di2el2)))))))
+    (average recall (filter set/intersection (combo/subsets (keys dict1)))
+    ; (for [keyval1 dict1 keyval2 dict1]
+    ;     (do (let [di2el1 (set (dict2 (key keyval1)))
+    ;               di2el2 (set (dict2 (key keyval2)))]
+    ;         (if (set/intersection di2el1 di2el2)
+    ;             (let [di1el1 (set (dict1 (key keyval1)))
+    ;                   di1el2 (set (dict1 (key keyval2)))]
+    ;             (recall di1el1 di1el2 di2el1 di2el2)))))))
 
 (defn precision [set1_1 set1_2 set2_1 set2_2]
     (float (/ (min (float (count (set/intersection set1_1 set1_2)))

--- a/src/clojure_bcubed/core.clj
+++ b/src/clojure_bcubed/core.clj
@@ -11,39 +11,79 @@
 
 (defn average [numbers] (/ (apply + numbers) (count numbers)))
 
-(defn recall [set1_1 set1_2 set2_1 set2_2]
-    (float (/ (min (float (count (set/intersection set1_1 set1_2)))
-                   (float (count (set/intersection set2_1 set2_2))))
-              (float (count (set/intersection set2_1 set2_2))))))
-
-(defn multi-recall [ldict cdict]
-  (filter
-    (fn [l] (not= #{} (set/intersection (ldict (first l)) (ldict (last l)))))
-    (combo/selections (keys cdict) 2)
+(defn multi-recall [categories clusters el1 el2]
+  (let
+    [
+      clusters-intersection (count (set/intersection (clusters el1) (clusters el2)))
+      categories-intersection (count (set/intersection (categories el1) (categories el2)))
+    ]
+    (float (/ (min clusters-intersection categories-intersection)
+              categories-intersection))
   )
-    (average recall (filter (fn [l] (set/intersection (ldict (first l)) (ldict (last l)) (combo/selections (keys cdict)))))
-    ; (for [keyval1 dict1 keyval2 dict1]
-    ;     (do (let [di2el1 (set (dict2 (key keyval1)))
-    ;               di2el2 (set (dict2 (key keyval2)))]
-    ;         (if (set/intersection di2el1 di2el2)
-    ;             (let [di1el1 (set (dict1 (key keyval1)))
-    ;                   di1el2 (set (dict1 (key keyval2)))]
-    ;             (recall di1el1 di1el2 di2el1 di2el2)))))))
+)
 
-(defn precision [set1_1 set1_2 set2_1 set2_2]
-    (float (/ (min (float (count (set/intersection set1_1 set1_2)))
-                   (float (count (set/intersection set2_1 set2_2))))
-              (float (count (set/intersection set1_1 set1_2))))))
+(defn recall [categories clusters]
+  (log/info "Starting recall")
+  (average
+    (map
+      (partial apply (partial multi-recall categories clusters))
+      (filter
+        (partial apply (fn [el1 el2] (not= #{} (set/intersection (categories el1) (categories el2)))))
+        (combo/selections (keys clusters) 2)
+      )
+    )
+  )
+)
 
-(defn multi-precision [dict1 dict2]
-    (log/info "Starting precision")
-    (for [keyval1 dict1 keyval2 dict1]
-        (do (let [di1el1 (set (dict1 (key keyval1)))
-                  di1el2 (set (dict1 (key keyval2)))]
-            (if (set/intersection di1el1 di1el2)
-                (let [di2el1 (set (dict2 (key keyval1)))
-                      di2el2 (set (dict2 (key keyval2)))]
-                (precision di1el1 di1el2 di2el1 di2el2)))))))
+(defn recall-sensible [categories clusters]
+  (log/info "Starting recall-sensible")
+  (average
+    (map
+      (partial apply (partial multi-recall categories clusters))
+      (filter
+        (partial apply (fn [el1 el2] (not= #{} (set/intersection (categories el1) (categories el2)))))
+        (combo/combinations (keys clusters) 2)
+      )
+    )
+  )
+)
+
+(defn multi-precision [categories clusters el1 el2]
+  (let
+    [
+      clusters-intersection (count (set/intersection (clusters el1) (clusters el2)))
+      categories-intersection (count (set/intersection (categories el1) (categories el2)))
+    ]
+    (float (/ (min clusters-intersection categories-intersection)
+              clusters-intersection))
+  )
+)
+
+(defn precision [categories clusters]
+  (log/info "Starting precision")
+  (average
+    (map
+      (partial apply (partial multi-precision categories clusters))
+      (filter
+        (partial apply (fn [el1 el2] (not= #{} (set/intersection (clusters el1) (clusters el2)))))
+        (combo/selections (keys clusters) 2)
+      )
+    )
+  )
+)
+
+(defn precision-sensible [categories clusters]
+  (log/info "Starting precision-sensible")
+  (average
+    (map
+      (partial apply (partial multi-precision categories clusters))
+      (filter
+        (partial apply (fn [el1 el2] (not= #{} (set/intersection (clusters el1) (clusters el2)))))
+        (combo/combinations (keys clusters) 2)
+      )
+    )
+  )
+)
 
 (defn -main [& args]
   true


### PR DESCRIPTION
I tried to implement all four metrics in a somewhat more functional way.

Changes in algorithm:
- compute list of keys using clojure.math.combinatorics/selections (for ordered pairs) and clojure.math.combinatorics/combinations (for unordered pairs, i.e. sensible metrics)
- filter those where the relevant dict values have non-empty intersection
- apply the respective computation to those pairs

Changes in API:
- I changed the parameter names to categories/clusters (as in clustering_metrics) with categories coming first, because otherwise I get hopelessly confused.
- I swapped the names with and without "multi-" prefix around to match those in python-bcubed

Unrelated changes:
- I couldn't install with-command-line because it is deprecated, so I removed the code in -main for the time being.

TODOs:
- test computation of metrics, e.g. comparing with Python
- verify that all list evaluations are done lazily (I think average is non-lazy because it probably has to load the whole list for count)
- reintroduce code into -main for reading dictionaries from JSON files (I think we should use [clojure.tools/parse-opts](https://github.com/clojure/tools.cli))
